### PR TITLE
build: copy go.mod and go.sum into docker build process

### DIFF
--- a/argocd.Dockerfile
+++ b/argocd.Dockerfile
@@ -14,6 +14,8 @@ RUN mkdir -p /gopath sigs.k8s.io && \
     git clone https://github.com/kubernetes-sigs/kustomize.git sigs.k8s.io/kustomize && \
     (cd sigs.k8s.io/kustomize; git checkout ${KUSTOMIZE_VERSION}) && \
     cp SecretsFromVault.go sigs.k8s.io/kustomize/plugin/ && \
+    cp go.mod sigs.k8s.io/kustomize/ && \
+    cp go.sum sigs.k8s.io/kustomize/ && \
     cd sigs.k8s.io/kustomize && \
     git apply ../../kustomize.patch && \
     git apply ../../kustomize-enable.patch && \


### PR DESCRIPTION
- copy go modules and checksum file into docker build process to resolve module not found error:
<img width="1007" alt="Screenshot 2024-08-24 at 9 36 29 PM" src="https://github.com/user-attachments/assets/f90272b8-c9ca-46b5-8f95-9b6a14e6946b">
